### PR TITLE
Fix regression in offline install script

### DIFF
--- a/install/offline/install.bat
+++ b/install/offline/install.bat
@@ -19,8 +19,8 @@ goto EndOfLicense
 SET iserr=0
 SET SCRIPTDIR=%~dp0
 SET DARTROOTDIR=%~dp0..\..\
-SET DOWNLOADSDIR="%SCRIPTDIR%downloads\ "
-SET REQUIREMENTSFILE="%~dp0..\..\requirements.txt "
+SET DOWNLOADSDIR=%SCRIPTDIR%downloads\
+SET REQUIREMENTSFILE=%~dp0..\..\requirements.txt 
 
 REM DART Offline Installation
 REM Copyright 2017 Lockheed Martin Corporation


### PR DESCRIPTION
Remove quotes and adjust spacing in offline install script path definitions. Believe this'll resolve the bug reported in #1.